### PR TITLE
feat: add crypto_box_seal

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,29 @@ Clamping involves clearing the lowest 3 bits of the result, ensuring the result 
   crypto_secretstream_xchacha20poly1305_TAG_FINAL
 ```
 
+#### `crypto_box`
+
+[Sealed box encryption](https://sodium-friends.github.io/docs/docs/sealedboxencryption)
+
+#### Methods
+
+```
+  crypto_box_keypair
+  crypto_box_seal
+  crypto_box_seal_open
+```
+
+#### Constants
+
+```
+  crypto_box_SEALBYTES
+  crypto_box_PUBLICKEYBYTES
+  crypto_box_SECRETKEYBYTES
+  crypto_box_SEEDBYTES
+  crypto_box_NONCEBYTES
+  crypto_box_MACBYTES
+```
+
 #### `crypto_secretbox`
 
 [Secret key box encryption](https://sodium-friends.github.io/docs/docs/secretkeyboxencryption)

--- a/android/src/main/cpp/sodium-jni.c
+++ b/android/src/main/cpp/sodium-jni.c
@@ -1130,6 +1130,108 @@ Java_com_sodiumreactnative_jni_SodiumReactNativeJNI_crypto_1stream_1noncebytes(
   return (jint)crypto_stream_NONCEBYTES;
 }
 
+JNIEXPORT jint JNICALL
+Java_com_sodiumreactnative_jni_SodiumReactNativeJNI_crypto_1box_1sealbytes(
+  JNIEnv *env,
+  jclass clazz
+) {
+  return (jint)crypto_box_SEALBYTES;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_sodiumreactnative_jni_SodiumReactNativeJNI_crypto_1box_1publickeybytes(
+  JNIEnv *env,
+  jclass clazz
+) {
+  return (jint)crypto_box_PUBLICKEYBYTES;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_sodiumreactnative_jni_SodiumReactNativeJNI_crypto_1box_1secretkeybytes(
+  JNIEnv *env,
+  jclass clazz
+) {
+  return (jint)crypto_box_SECRETKEYBYTES;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_sodiumreactnative_jni_SodiumReactNativeJNI_crypto_1box_1seedbytes(
+  JNIEnv *env,
+  jclass clazz
+) {
+  return (jint)crypto_box_SEEDBYTES;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_sodiumreactnative_jni_SodiumReactNativeJNI_crypto_1box_1noncebytes(
+  JNIEnv *env,
+  jclass clazz
+) {
+  return (jint)crypto_box_NONCEBYTES;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_sodiumreactnative_jni_SodiumReactNativeJNI_crypto_1box_1macbytes(
+  JNIEnv *env,
+  jclass clazz
+) {
+  return (jint)crypto_box_MACBYTES;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_sodiumreactnative_jni_SodiumReactNativeJNI_crypto_1box_1keypair(
+  JNIEnv *jenv,
+  jclass clazz,
+  jbyteArray j_pk,
+  jbyteArray j_sk
+) {
+  unsigned char *pk = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_pk, 0);
+  unsigned char *sk = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_sk, 0);
+
+  int result = crypto_box_keypair(pk, sk);
+  (*jenv)->ReleaseByteArrayElements(jenv, j_pk, (jbyte *) pk, 0);
+  (*jenv)->ReleaseByteArrayElements(jenv, j_sk, (jbyte *) sk, 0);
+  return (jint)result;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_sodiumreactnative_jni_SodiumReactNativeJNI_crypto_1box_1seal(
+  JNIEnv *jenv,
+  jclass clazz,
+  jbyteArray j_c,
+  jbyteArray j_m,
+  jint j_mlen,
+  jbyteArray j_pk
+) {
+  unsigned char *c = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_c, 0);
+  unsigned char *m = as_unsigned_char_array(jenv, j_m);
+  unsigned char *pk = as_unsigned_char_array(jenv, j_pk);
+
+  int result = crypto_box_seal(c, m, j_mlen, pk);
+  (*jenv)->ReleaseByteArrayElements(jenv, j_c, (jbyte *) c, 0);
+  return (jint)result;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_sodiumreactnative_jni_SodiumReactNativeJNI_crypto_1box_1seal_1open(
+  JNIEnv *jenv,
+  jclass clazz,
+  jbyteArray j_m,
+  jbyteArray j_c,
+  jint j_clen,
+  jbyteArray j_pk,
+  jbyteArray j_sk
+) {
+  unsigned char *m = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_m, 0);
+  unsigned char *c = as_unsigned_char_array(jenv, j_c);
+  unsigned char *pk = as_unsigned_char_array(jenv, j_pk);
+  unsigned char *sk = as_unsigned_char_array(jenv, j_sk);
+
+  int result = crypto_box_seal_open(m, c, j_clen, pk, sk);
+  (*jenv)->ReleaseByteArrayElements(jenv, j_m, (jbyte *) m, 0);
+  return (jint)result;
+}
+
 /* *****************************************************************************
  * Key exchange
  * *****************************************************************************

--- a/android/src/main/java/com/sodiumreactnative/SodiumReactNativeModule.java
+++ b/android/src/main/java/com/sodiumreactnative/SodiumReactNativeModule.java
@@ -119,22 +119,22 @@ public class SodiumReactNativeModule extends ReactContextBaseJavaModule {
     constants.put("crypto_sign_SECRETKEYBYTES", SodiumReactNative.crypto_sign_secretkeybytes());
     constants.put("crypto_stream_KEYBYTES", SodiumReactNative.crypto_stream_keybytes());
     constants.put("crypto_stream_NONCEBYTES", SodiumReactNative.crypto_stream_noncebytes());
+    constants.put("crypto_box_SEALBYTES", SodiumReactNative.crypto_box_sealbytes());
+    constants.put("crypto_box_SEEDBYTES", SodiumReactNative.crypto_box_seedbytes());
+    constants.put("crypto_box_PUBLICKEYBYTES", SodiumReactNative.crypto_box_publickeybytes());
+    constants.put("crypto_box_SECRETKEYBYTES", SodiumReactNative.crypto_box_secretkeybytes());
+    constants.put("crypto_box_NONCEBYTES", SodiumReactNative.crypto_box_noncebytes());
+    constants.put("crypto_box_MACBYTES", SodiumReactNative.crypto_box_macbytes());
 
     // These may be useful for future extensions
 
     // constants.put("crypto_auth_BYTES", SodiumReactNative.crypto_auth_bytes());
     // constants.put("crypto_auth_KEYBYTES", SodiumReactNative.crypto_auth_keybytes());
     // constants.put("crypto_hash_BYTES", SodiumReactNative.crypto_hash_bytes());
-    // constants.put("crypto_box_SEEDBYTES", SodiumReactNative.crypto_box_seedbytes());
-    // constants.put("crypto_box_PUBLICKEYBYTES", SodiumReactNative.crypto_box_publickeybytes());
-    // constants.put("crypto_box_SECRETKEYBYTES", SodiumReactNative.crypto_box_secretkeybytes());
-    // constants.put("crypto_box_NONCEBYTES", SodiumReactNative.crypto_box_noncebytes());
-    // constants.put("crypto_box_MACBYTES", SodiumReactNative.crypto_box_macbytes());
     // constants.put("crypto_hash_sha256_STATEBYTES", SodiumReactNative.crypto_hash_sha256_statebytes());
     // constants.put("crypto_hash_sha512_STATEBYTES", SodiumReactNative.crypto_hash_sha512_statebytes());
     // constants.put("crypto_stream_xor_STATEBYTES", SodiumReactNative.crypto_stream_xor_statebytes());
     // constants.put("crypto_stream_chacha20_xor_STATEBYTES", SodiumReactNative.crypto_stream_chacha20_xor_statebytes());
-    // constants.put("crypto_box_SEALBYTES", SodiumReactNative.crypto_box_sealbytes());
     // constants.put("crypto_hash_sha256_BYTES", SodiumReactNative.crypto_hash_sha256_bytes());
     // constants.put("crypto_pwhash_scryptsalsa208sha256_BYTES_MIN", SodiumReactNative.crypto_pwhash_scryptsalsa208sha256_bytes_min());
     // constants.put("crypto_pwhash_scryptsalsa208sha256_BYTES_MAX", SodiumReactNative.crypto_pwhash_scryptsalsa208sha256_bytes_max());
@@ -1210,5 +1210,95 @@ public class SodiumReactNativeModule extends ReactContextBaseJavaModule {
     SodiumReactNative.sodium_unpad(unpadded_buflen, _buf, padded_buflen, blocksize);
 
     return ArrayUtil.toWritableArray( Arrays.copyOfRange(_buf, 0, unpadded_buflen[0] ) );
+  }
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public WritableArray crypto_box_keypair (
+    ReadableArray pk,
+    ReadableArray sk
+  ) throws Exception {
+    byte[] _pk = ArgumentsEx.toByteArray(pk);
+    byte[] _sk = ArgumentsEx.toByteArray(sk);
+
+    try {
+      ArgumentsEx.check(_pk, SodiumReactNative.crypto_box_publickeybytes(), "ERR_BAD_KEY");
+      ArgumentsEx.check(_sk, SodiumReactNative.crypto_box_secretkeybytes(), "ERR_BAD_KEY");
+    } catch (Exception e) {
+      throw e;
+    }
+
+    int success = SodiumReactNative.crypto_box_keypair(_pk, _sk);
+    if (success != 0) {
+      Exception e = new Exception("crypto_box_keypair execution failed");
+      throw e;
+    }
+
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream( );
+
+    try {
+      outputStream.write( _pk );
+      outputStream.write( _sk );
+    } catch (IOException e) {
+      throw e;
+    }
+
+    byte ret[] = outputStream.toByteArray( );
+
+    return ArrayUtil.toWritableArray(ret);
+  }
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public WritableArray crypto_box_seal (
+    ReadableArray c,
+    ReadableArray m,
+    ReadableArray pk
+  ) throws Exception {
+    byte[] _c = ArgumentsEx.toByteArray(c);
+    byte[] _m = ArgumentsEx.toByteArray(m);
+    byte[] _pk = ArgumentsEx.toByteArray(pk);
+
+    try {
+      ArgumentsEx.check(_pk, SodiumReactNative.crypto_box_publickeybytes(), "ERR_BAD_KEY");
+      ArgumentsEx.check(_c, _m.length + SodiumReactNative.crypto_box_sealbytes(), "ERR_BAD_CIPHERTEXT_LENGTH");
+    } catch (Exception e) {
+      throw e;
+    }
+
+    int success = SodiumReactNative.crypto_box_seal(_c, _m, _m.length, _pk);
+    if (success != 0) {
+      Exception e = new Exception("crypto_box_seal execution failed");
+      throw e;
+    }
+
+    return ArrayUtil.toWritableArray(_c);
+  }
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public WritableArray crypto_box_seal_open (
+    ReadableArray m,
+    ReadableArray c,
+    ReadableArray pk,
+    ReadableArray sk
+  ) throws Exception {
+    byte[] _m = ArgumentsEx.toByteArray(m);
+    byte[] _c = ArgumentsEx.toByteArray(c);
+    byte[] _pk = ArgumentsEx.toByteArray(pk);
+    byte[] _sk = ArgumentsEx.toByteArray(sk);
+
+    try {
+      ArgumentsEx.check(_pk, SodiumReactNative.crypto_box_publickeybytes(), "ERR_BAD_KEY");
+      ArgumentsEx.check(_sk, SodiumReactNative.crypto_box_secretkeybytes(), "ERR_BAD_KEY");
+      ArgumentsEx.check(_m, _c.length - SodiumReactNative.crypto_box_sealbytes(), "ERR_BAD_PLAINTEXT_LENGTH");
+    } catch (Exception e) {
+      throw e;
+    }
+
+    int success = SodiumReactNative.crypto_box_seal_open(_m, _c, _c.length, _pk, _sk);
+    if (success != 0) {
+      Exception e = new Exception("crypto_box_seal_open execution failed");
+      throw e;
+    }
+
+    return ArrayUtil.toWritableArray(_m);
   }
 }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -267,6 +267,37 @@ export default function App() {
     setResult(decoded);
   };
 
+  const onCryptoBoxSeal = async () => {
+    const message = b4a.from('Hello, World!');
+    const cipherText = new Uint8Array(
+      message.byteLength + sodium.crypto_box_SEALBYTES
+    );
+    const pk = new Uint8Array(sodium.crypto_box_PUBLICKEYBYTES);
+    const sk = new Uint8Array(sodium.crypto_box_SECRETKEYBYTES);
+
+    try {
+      sodium.crypto_box_keypair(pk, sk);
+      console.log({ pk: b4a.toString(pk, 'hex') });
+      console.log({ sk: b4a.toString(sk, 'hex') });
+      sodium.crypto_box_seal(cipherText, message, pk);
+      const encrypted = b4a.toString(cipherText, 'hex');
+      console.log({ encrypted });
+      setResult(`Encrypted: ${encrypted}\nDecrypting in 2 seconds...`);
+      await sleep(2000);
+
+      const decrypted = new Uint8Array(
+        cipherText.byteLength - sodium.crypto_box_SEALBYTES
+      );
+      sodium.crypto_box_seal_open(decrypted, cipherText, pk, sk);
+      const decoded = b4a.toString(decrypted);
+      console.log({ decoded });
+      setResult(`Decrypted: ${decoded}`);
+    } catch (error: any) {
+      console.log(error);
+      setResult(error.message);
+    }
+  };
+
   const openTests = () => {
     setShowTests(true);
   };
@@ -337,6 +368,11 @@ export default function App() {
           style={styles.button}
           title="RandomBytesBuf"
           onPress={onRandomBytesBuf}
+        />
+        <Button
+          style={styles.button}
+          title="CryptoBoxSeal"
+          onPress={onCryptoBoxSeal}
         />
         <Button style={styles.button} title="Open tests" onPress={openTests} />
       </View>

--- a/ios/SodiumReactNative.mm
+++ b/ios/SodiumReactNative.mm
@@ -123,6 +123,12 @@ RCT_EXPORT_MODULE()
     @"crypto_sign_SEEDBYTES": @ crypto_sign_SEEDBYTES,
     @"crypto_stream_KEYBYTES": @ crypto_stream_KEYBYTES,
     @"crypto_stream_NONCEBYTES": @ crypto_stream_NONCEBYTES,
+    @"crypto_box_SEALBYTES": @ crypto_box_SEALBYTES,
+    @"crypto_box_PUBLICKEYBYTES": @ crypto_box_PUBLICKEYBYTES,
+    @"crypto_box_SECRETKEYBYTES": @ crypto_box_SECRETKEYBYTES,
+    @"crypto_box_SEEDBYTES": @ crypto_box_SEEDBYTES,
+    @"crypto_box_NONCEBYTES": @ crypto_box_NONCEBYTES,
+    @"crypto_box_MACBYTES": @ crypto_box_MACBYTES,
   };
 }
 
@@ -894,6 +900,46 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(
   RN_CHECK_FAILURE(crypto_kx_seed_keypair(pk_data, sk_data, seed_data))
 
   RN_RETURN_BUFFERS_2(pk, sk, sklen)
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(
+  crypto_box_keypair: (NSArray *) pk sk: (NSArray *) sk)
+{
+  RN_RESULT_BUFFER(pk, crypto_box_PUBLICKEYBYTES, ERR_BAD_KEY)
+  RN_RESULT_BUFFER(sk, crypto_box_SECRETKEYBYTES, ERR_BAD_KEY)
+
+  crypto_box_keypair(pk_data, sk_data);
+
+  RN_RETURN_BUFFERS_2(pk, sk, sklen)
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(
+  crypto_box_seal:(NSArray*)c m:(NSArray*)m pk:(NSArray*)pk)
+{
+  RN_ARG_BUFFER_NO_CHECK(pk)
+  RN_ARG_BUFFER_NO_CHECK(m)
+
+  unsigned long long clen_check = mlen + crypto_box_SEALBYTES;
+  RN_RESULT_BUFFER(c, clen_check, ERR_BAD_CIPHERTEXT)
+
+  RN_CHECK_FAILURE(crypto_box_seal(c_data, m_data, mlen, pk_data))
+
+  RN_RETURN_BUFFER(c)
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(
+  crypto_box_seal_open:(NSArray*)m c:(NSArray*)c pk:(NSArray*)pk sk:(NSArray*)sk)
+{
+  RN_ARG_BUFFER_NO_CHECK(pk)
+  RN_ARG_BUFFER_NO_CHECK(sk)
+  RN_ARG_BUFFER_NO_CHECK(c)
+
+  unsigned long long mlen_check = clen - crypto_box_SEALBYTES;
+  RN_RESULT_BUFFER(m, mlen_check, ERR_BAD_MESSAGE_LENGTH)
+
+  RN_CHECK_FAILURE(crypto_box_seal_open(m_data, c_data, clen, pk_data, sk_data))
+
+  RN_RETURN_BUFFER(m)
 }
 
 @end

--- a/src/crypto_box.ts
+++ b/src/crypto_box.ts
@@ -1,0 +1,56 @@
+import { Libsodium } from './libsodium';
+import { mapArgs } from './helpers';
+import { constants } from './constants';
+
+export const crypto_box_PUBLICKEYBYTES = constants.crypto_box_PUBLICKEYBYTES;
+export const crypto_box_SECRETKEYBYTES = constants.crypto_box_SECRETKEYBYTES;
+export const crypto_box_SEEDBYTES = constants.crypto_box_SEEDBYTES;
+export const crypto_box_NONCEBYTES = constants.crypto_box_NONCEBYTES;
+export const crypto_box_MACBYTES = constants.crypto_box_MACBYTES;
+export const crypto_box_SEALBYTES = constants.crypto_box_SEALBYTES;
+
+/**
+ * Encrypts a message with the recipient's public key.
+ * https://sodium-friends.github.io/docs/docs/keyboxencryption#crypto_box_keypair
+ */
+export function crypto_box_keypair(pk: Uint8Array, sk: Uint8Array) {
+  const nativeResult = Libsodium.crypto_box_keypair(
+    ...Array.from([pk, sk], mapArgs)
+  );
+  const res = new Uint8Array(nativeResult);
+  pk.set(res.subarray(0, crypto_box_PUBLICKEYBYTES));
+  sk.set(res.subarray(crypto_box_PUBLICKEYBYTES));
+}
+
+/**
+ * Keypairs can be generated with crypto_box_keypair() or crypto_box_seed_keypair().
+ * https://sodium-friends.github.io/docs/docs/sealedboxencryption#crypto_box_seal
+ */
+export function crypto_box_seal(
+  cipherText: Uint8Array,
+  message: Uint8Array,
+  publicKey: Uint8Array
+) {
+  const nativeResult = Libsodium.crypto_box_seal(
+    ...Array.from([cipherText, message, publicKey], mapArgs)
+  );
+  const res = new Uint8Array(nativeResult);
+  cipherText.set(res);
+}
+
+/**
+ * Decrypts a message encoded with the sealed box method.
+ * https://sodium-friends.github.io/docs/docs/sealedboxencryption#crypto_box_seal_open
+ */
+export function crypto_box_seal_open(
+  message: Uint8Array,
+  cipherText: Uint8Array,
+  publicKey: Uint8Array,
+  privateKey: Uint8Array
+) {
+  const nativeResult = Libsodium.crypto_box_seal_open(
+    ...Array.from([message, cipherText, publicKey, privateKey], mapArgs)
+  );
+  const res = new Uint8Array(nativeResult);
+  message.set(res);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as constants from './constants';
 import * as crypto_aead from './crypto_aead';
 // import * as crypto_auth from './crypto_auth';
-// import * as crypto_box from './crypto_box';
+import * as crypto_box from './crypto_box';
 import * as crypto_core from './crypto_core';
 import * as crypto_generichash from './crypto_generichash';
 import * as crypto_hash from './crypto_hash';
@@ -26,7 +26,7 @@ const sodium = {
   ...constants,
   ...crypto_aead,
   // ...crypto_auth,
-  // ...crypto_box,
+  ...crypto_box,
   ...crypto_core,
   ...crypto_generichash,
   ...crypto_hash,

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,4 +74,10 @@ export type Constants = {
   crypto_sign_SECRETKEYBYTES: number;
   crypto_stream_KEYBYTES: number;
   crypto_stream_NONCEBYTES: number;
+  crypto_box_SEALBYTES: number;
+  crypto_box_PUBLICKEYBYTES: number;
+  crypto_box_SECRETKEYBYTES: number;
+  crypto_box_SEEDBYTES: number;
+  crypto_box_NONCEBYTES: number;
+  crypto_box_MACBYTES: number;
 };


### PR DESCRIPTION

This pull request includes changes to the `sodium-react-native` library to add support for sealed box encryption using the `crypto_box` module from the `libsodium` library. The most important changes include the addition of new methods and constants related to sealed box encryption in the `crypto_box` module, the addition of JNI methods in the `SodiumReactNativeJNI` class to expose these new methods and constants to Java, and the addition of a new test in the example app to demonstrate sealed box encryption.

New methods and constants in `crypto_box` module:

* [`src/crypto_box.ts`](diffhunk://#diff-dee6259d27f581c33cfc82d8e8bf7a32ac95e64548dde782d64a3d5cd4cdfa1eR1-R56): Added new methods `crypto_box_keypair`, `crypto_box_seal`, and `crypto_box_seal_open` for key pair generation and sealed box encryption and decryption. Also added new constants related to sealed box encryption.

JNI methods in `SodiumReactNativeJNI`:

* [`android/src/main/cpp/sodium-jni.c`](diffhunk://#diff-f610b0ebeb3e575ed29aa8ca067446cf145d8bdb0b1f825cc37258b5564f51e6R1133-R1234): Added new JNI methods to expose the new `crypto_box` methods and constants to Java.

Updates to `SodiumReactNativeModule`:

* [`android/src/main/java/com/sodiumreactnative/SodiumReactNativeModule.java`](diffhunk://#diff-59cc81ae525b779db07044abc1645a07812f114fdb31a8a5cd87750d56688a78R1214-R1303): Added new methods corresponding to the new JNI methods in the `SodiumReactNativeJNI` class.
* [`ios/SodiumReactNative.mm`](diffhunk://#diff-860bb814852672ab13c5e40a3afb239358e6f25df086d2629a89a3b31913ccb5R905-R944): Added new methods corresponding to the new JNI methods in the `SodiumReactNativeJNI` class.

Updates to `README.md`:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R258-R280): Added a new section to the documentation for the `crypto_box` module.

Test in example app:

* [`example/src/App.tsx`](diffhunk://#diff-6a99c076036be89e153c671ac5e086623e32b13dfa5a46df98293d472c422010R270-R300): Added a new test to demonstrate sealed box encryption.

Other changes:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L4-R4): Exposed the new methods and constants in the `crypto_box` module.
* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR77-R82): Added new constants related to sealed box encryption.